### PR TITLE
Relax the constraint on plain codec

### DIFF
--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
 
   s.add_runtime_dependency 'addressable'
-  s.add_runtime_dependency 'logstash-codec-plain', '~> 0.1.6'
+  s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'ftw', '~> 0.0.42'
 
   s.add_development_dependency 'logstash-devutils', '~> 0'


### PR DESCRIPTION
Remove the constraint on plain codec as it is best inherited from logstash gemspec
Fix for #8 