### PR TITLE
Add missing dependency for rack, fixes issue #11

### DIFF
--- a/lib/logstash/inputs/github.rb
+++ b/lib/logstash/inputs/github.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "socket"
 require "json"
+require "rack"
 
 # Read events from github webhooks
 class LogStash::Inputs::GitHub < LogStash::Inputs::Base


### PR DESCRIPTION
The call to `Rack::Utils.secure_compare(hash, sign_header)` results in an exception thrown and then logstash crashes. More info in issue #11.  

This pull request includes the missing dependency.
