### PR TITLE
Fixing NoMethodError: undefined method `headers_'

### DIFF
--- a/lib/logstash/inputs/github.rb
+++ b/lib/logstash/inputs/github.rb
@@ -29,7 +29,7 @@ class LogStash::Inputs::GitHub < LogStash::Inputs::Base
   def run(output_queue)
     @server = FTW::WebServer.new(@ip, @port) do |request, response|
         body = request.read_body
-        event = build_event_from_request(body, request.headers_.to_hash)
+        event = build_event_from_request(body, request.headers.to_hash)
         valid_event = verify_signature(event,body)
         if !valid_event && @drop_invalid
           @logger.info("Dropping invalid Github message")


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

I'm getting this stack trace with logstash 5.0.0, this change fixes it.
``` 
[2016-11-10T20:02:17,433][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<NoMethodError: undefined method `headers_' for #<FTW::Request:0x14197a76>>, :backtrace=>["/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-github-3.0.1/lib/logstash/inputs/github.rb:32:in `run'", "org/jruby/RubyProc.java:281:in `call'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.44/lib/ftw/webserver.rb:77:in `handle_request'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.44/lib/ftw/webserver.rb:59:in `handle_connection'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/ftw-0.0.44/lib/ftw/webserver.rb:29:in `run'"]}
``` 
