### PR TITLE
Improve malformed-input handling, restarting, and crash-recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.6
+  - Improve malformed-input handling by using updated FTW
+  - Improve webserver crash recovery
+  - Properly support plugin stopping & reloading
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-github'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a GitHub webhook"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'addressable'
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'ftw', '~> 0.0.42'
+  s.add_runtime_dependency 'ftw', '~> 0.0.48'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
FTW v0.48 was recently shipped, fixing a crash that could happen when the
webserver was sent an `HTTP/0.9` request (what is this, 1991!?), and fixing
a scenario where the webserver would fail to return when stopped.

Also properly overrides `LogStash::Inputs::Base#stop`, so we can ensure our
server gets stopped when the plugin is stopped or reloaded.
