### PR TITLE
Reject reqs missing x-hub-signature header if secret_token defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.8
+  - Require x-hub-signature header if secret_token defined
+
 ## 3.0.7
   - Docs: Set the default_codec doc attribute.
 
@@ -28,4 +31,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/inputs/github.rb
+++ b/lib/logstash/inputs/github.rb
@@ -72,6 +72,9 @@ class LogStash::Inputs::GitHub < LogStash::Inputs::Base
         event.tag("_Invalid_Github_Message")
         is_valid = false
       end
+    elsif @secret_token && !sign_header
+        event.tag("_Invalid_Github_Message")
+        is_valid = false
     end
     return is_valid
   end

--- a/lib/logstash/inputs/github.rb
+++ b/lib/logstash/inputs/github.rb
@@ -63,20 +63,18 @@ class LogStash::Inputs::GitHub < LogStash::Inputs::Base
   end
 
   def verify_signature(event,body)
-    is_valid = true
+    # skip validation if we have no secret token
+    return true unless @secret_token
+
     sign_header = event.get("[headers][x-hub-signature]")
-    if @secret_token && sign_header
+    if sign_header
       hash = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), @secret_token, body)
       event.set("hash", hash)
-      if not Rack::Utils.secure_compare(hash, sign_header)
-        event.tag("_Invalid_Github_Message")
-        is_valid = false
-      end
-    elsif @secret_token && !sign_header
-        event.tag("_Invalid_Github_Message")
-        is_valid = false
+      return true if Rack::Utils.secure_compare(hash, sign_header)
     end
-    return is_valid
+
+    event.tag("_Invalid_Github_Message")
+    return false
   end
 
   def stop

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-github'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a GitHub webhook"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -28,4 +28,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/inputs/github_spec.rb
+++ b/spec/inputs/github_spec.rb
@@ -26,18 +26,18 @@ describe  LogStash::Inputs::GitHub do
     end
   end
 
-  describe "verify webhook signature" do
+  describe "verify webhook signature if token provided" do
     let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999, "secret_token" => "my_secret"} ) }
     let(:body) {IO.read("spec/fixtures/event_create.json")}
     let(:headers) { {"x-hub-signature" => "hash"} }
     let(:event) {plugin.build_event_from_request(body,headers)}
     let(:hash) { "sha1=43b113fc453c47f1cd4d5b4ded2985581c00a715" }
 
-    it "accept event without signature" do
+    it "reject event without signature" do
       event.set('headers',{})
-      expect(plugin.verify_signature(event,body)).to eq(true)
+      expect(plugin.verify_signature(event,body)).to eq(false)
       expect(event.get("hash")).to be_nil
-      expect(event.get("tags")).to be_nil
+      expect(event.get("tags")).to eq(["_Invalid_Github_Message"])
     end
 
     it "reject event with invalid signature" do
@@ -51,6 +51,36 @@ describe  LogStash::Inputs::GitHub do
       event.set('headers', {"x-hub-signature" => hash})
       expect(plugin.verify_signature(event,body)).to eq(true)
       expect(event.get("hash")).to eq(hash)
+      expect(event.get("tags")).to be_nil
+    end
+
+  end
+
+  describe "don't validate webhook if token missing" do
+    let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999} ) }
+    let(:body) {IO.read("spec/fixtures/event_create.json")}
+    let(:headers) { {"x-hub-signature" => "hash"} }
+    let(:event) {plugin.build_event_from_request(body,headers)}
+    let(:hash) { "sha1=43b113fc453c47f1cd4d5b4ded2985581c00a715" }
+
+    it "accept event without signature" do
+      event.set('headers',{})
+      expect(plugin.verify_signature(event,body)).to eq(true)
+      expect(event.get("hash")).to be_nil
+      expect(event.get("tags")).to be_nil
+    end
+
+    it "accept event with invalid signature" do
+      event.set('headers',{"x-hub-signature" => "invalid"})
+      expect(plugin.verify_signature(event,body)).to eq(true)
+      expect(event.get("hash")).to be_nil
+      expect(event.get("tags")).to be_nil
+    end
+
+    it "accept event with valid signature" do
+      event.set('headers', {"x-hub-signature" => hash})
+      expect(plugin.verify_signature(event,body)).to eq(true)
+      expect(event.get("hash")).to be_nil
       expect(event.get("tags")).to be_nil
     end
 


### PR DESCRIPTION
Should fix #16 

Updates `verify_signature` to check for the absence of the `x-hub-signature` header when `secret_token` is defined, and treats such requests as invalid.

Also revises an existing test to match the new behavior, and adds three more tests to verify that we don't overcorrect by requiring (or checking) the header if `secret_token` is _not_ defined.