### PR TITLE
Update ftw gem dependency to 0.0.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+  - Bump ftw dependency to 0.0.49, for compatibility with Logstash 7.x
+
 ## 3.0.8
   - Require x-hub-signature header if secret_token defined
 

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-github'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a GitHub webhook"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'addressable'
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'ftw', '~> 0.0.48'
+  s.add_runtime_dependency 'ftw', '~> 0.0.49'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Allows newest versions of plugin to be installed on Logstash 7.x

Should fix #19 

Additional context: https://github.com/jordansissel/ruby-ftw/pull/43