### PR TITLE
Change config secret_token type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+## 3.0.11
+  - Change `secret_token` config type to `password` for better protection from leaks in debug logs [#23](https://github.com/logstash-plugins/logstash-input-github/pull/23)
+
 ## 3.0.10
   - Changed the transitive dependency `http_parser.rb` (ftw) version to `~-> 0.6.0` as newer versions are published without the java support.
-  - Fixed crashing when the request body payload is not a JSON object.  [#24](https://github.com/logstash-plugins/logstash-input-github/pull/24) 
+  - Fixed crashing when the request body payload is not a JSON object.  [#24](https://github.com/logstash-plugins/logstash-input-github/pull/24)  
 
 ## 3.0.9
   - Bump ftw dependency to 0.0.49, for compatibility with Logstash 7.x

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-drop_invalid>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ip>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|Yes
-| <<plugins-{type}s-{plugin}-secret_token>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-secret_token>> |<<password,password>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -71,7 +71,7 @@ The port to listen on
 [id="plugins-{type}s-{plugin}-secret_token"]
 ===== `secret_token` 
 
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Your GitHub Secret Token for the webhook

--- a/lib/logstash/inputs/github.rb
+++ b/lib/logstash/inputs/github.rb
@@ -16,7 +16,7 @@ class LogStash::Inputs::GitHub < LogStash::Inputs::Base
   config :port, :validate => :number, :required => true
 
   # Your GitHub Secret Token for the webhook
-  config :secret_token, :validate => :string, :required => false
+  config :secret_token, :validate => :password, :required => false
 
   # If Secret is defined, we drop the events that don't match.
   # Otherwise, we'll just add an invalid tag
@@ -77,7 +77,7 @@ class LogStash::Inputs::GitHub < LogStash::Inputs::Base
 
     sign_header = event.get("[headers][x-hub-signature]")
     if sign_header
-      hash = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), @secret_token, body)
+      hash = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), @secret_token.value, body)
       event.set("hash", hash)
       return true if Rack::Utils.secure_compare(hash, sign_header)
     end

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-github'
-  s.version         = '3.0.10'
+  s.version         = '3.0.11'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a GitHub webhook"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/github_spec.rb
+++ b/spec/inputs/github_spec.rb
@@ -153,4 +153,15 @@ describe  LogStash::Inputs::GitHub do
       end
     end
   end
+
+  describe "debugging `secret_token`" do
+    let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999, "secret_token" => ::LogStash::Util::Password.new("my_secret")} ) }
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+
+      plugin.register
+      plugin.logger.send(:debug, plugin.secret_token.to_s)
+    end
+  end
 end

--- a/spec/inputs/github_spec.rb
+++ b/spec/inputs/github_spec.rb
@@ -27,7 +27,7 @@ describe  LogStash::Inputs::GitHub do
   end
 
   describe "verify webhook signature if token provided" do
-    let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999, "secret_token" => "my_secret"} ) }
+    let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999, "secret_token" => ::LogStash::Util::Password.new("my_secret")} ) }
     let(:body) {IO.read("spec/fixtures/event_create.json")}
     let(:headers) { {"x-hub-signature" => "hash"} }
     let(:event) {plugin.build_event_from_request(body,headers)}


### PR DESCRIPTION
### Description
This PR ensures to protect the `:secret_token` from leaks in the debug logs.

- Closes #22 

### Test
```
# config
input {
  github {
      codec => "json"
      secret_token  => "super-secret"
      port => 5010
      drop_invalid => true
  }
}
output {
    stdout {
        codec => rubydebug
    }
}
```


```
# Log before change
[2022-12-05T13:24:04,008][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@port = 5010
      [2022-12-05T13:24:04,008][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@secret_token = "super-secret"

# Log after change
[2022-12-05T13:30:36,288][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@drop_invalid = true
      [2022-12-05T13:30:36,288][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@id = "c27c053a232808ba56d05a942571ee0710c5f162fb7b318346659d7f46f36cbc"
      [2022-12-05T13:30:36,288][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@port = 5010
      [2022-12-05T13:30:36,288][DEBUG][logstash.inputs.github   ] config LogStash::Inputs::GitHub/@secret_token = <password>
```