### PR TITLE
Fixed crashing when request body is not a JSON object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.10
-   - Fixed crashing when the request body payload is not a JSON object. [#24](https://github.com/logstash-plugins/logstash-input-github/pull/24)
+  - Changed the transitive dependency `http_parser.rb` (ftw) version to `~-> 0.6.0` as newer versions are published without the java support.
+  - Fixed crashing when the request body payload is not a JSON object.  [#24](https://github.com/logstash-plugins/logstash-input-github/pull/24) 
 
 ## 3.0.9
   - Bump ftw dependency to 0.0.49, for compatibility with Logstash 7.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.10
+   - Fixed crashing when the request body payload is not a JSON object. [#24](https://github.com/logstash-plugins/logstash-input-github/pull/24)
+
 ## 3.0.9
   - Bump ftw dependency to 0.0.49, for compatibility with Logstash 7.x
 

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'addressable'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'http_parser.rb', '~> 0.6.0'
   s.add_runtime_dependency 'ftw', '~> 0.0.49'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-input-github.gemspec
+++ b/logstash-input-github.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-github'
-  s.version         = '3.0.9'
+  s.version         = '3.0.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a GitHub webhook"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/github_spec.rb
+++ b/spec/inputs/github_spec.rb
@@ -86,6 +86,27 @@ describe  LogStash::Inputs::GitHub do
 
   end
 
+  describe "verify event builder" do
+    let(:plugin) { LogStash::Plugin.lookup("input", "github").new( {"port" => 9999} ) }
+    let(:body) {"{}"}
+    let(:event) {plugin.build_event_from_request(body, {})}
+
+    context 'when request body is a minimal JSON value' do
+      let(:body) {"123"}
+      it 'should add the body string into the message field and tag' do
+        expect(event.get("message")).to eq("123")
+        expect(event.get("tags")).to eq("_invalidjsonobject")
+      end
+    end
+
+    context 'when request body is a JSON object' do
+      let(:body) {'{"action": "create"}'}
+      it 'should parse the body' do
+        expect(event.get("action")).to eq("create")
+      end
+    end
+  end
+
   describe 'graceful shutdown' do
     context 'when underlying webserver crashes' do
 


### PR DESCRIPTION
## What does this PR do?
The JSON specification defines single values as valid JSON, it can be a string in double quotes, a number, true or false, or null. When the body is parsed, those values are transformed into their corresponding types. When those types aren't a `Hash` (aka JSON object),  it breaks the `LogStash::Event` constructor, and Logstash crashes and exits.

After this PR, any request in which the body payload is a minimal JSON value, will be processed and an extra tag (`_invalidjsonobject`) will be added to the event:

```ruby
LogStash::Event.new("message" => body, "tags" => "_invalidjsonobject")
```

## Related issues
Closes #21 